### PR TITLE
External Downtime Message

### DIFF
--- a/app/DoctrineMigrations/Version20130330194956.php
+++ b/app/DoctrineMigrations/Version20130330194956.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Application\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration,
+    Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your need!
+ */
+class Version20130330194956 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql", "Migration can only be executed safely on 'mysql'.");
+        
+        $this->addSql("CREATE TABLE config (config_name VARCHAR(255) NOT NULL, config_value VARCHAR(255) NOT NULL, PRIMARY KEY(config_name)) DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE = InnoDB");
+    }
+
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != "mysql", "Migration can only be executed safely on 'mysql'.");
+        
+        $this->addSql("DROP TABLE config");
+    }
+}

--- a/src/phpBB/StatusSiteBundle/Admin/ConfigAdmin.php
+++ b/src/phpBB/StatusSiteBundle/Admin/ConfigAdmin.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace phpBB\StatusSiteBundle\Admin;
+
+use Sonata\AdminBundle\Admin\Admin;
+use Sonata\AdminBundle\Datagrid\ListMapper;
+use Sonata\AdminBundle\Datagrid\DatagridMapper;
+use Sonata\AdminBundle\Form\FormMapper;
+
+class ConfigAdmin extends Admin
+{
+    protected function configureFormFields(FormMapper $formMapper)
+    {
+        $formMapper
+            ->add('config_name')
+            ->add('config_value')
+        ;
+    }
+
+    protected function configureDatagridFilters(DatagridMapper $datagridMapper)
+    {
+        $datagridMapper
+            ->add('config_name')
+            ->add('config_value')
+        ;
+    }
+
+    protected function configureListFields(ListMapper $listMapper)
+    {
+        $listMapper
+            ->addIdentifier('config_name')
+            ->add('config_value')
+        ;
+    }
+}

--- a/src/phpBB/StatusSiteBundle/Controller/ApiController.php
+++ b/src/phpBB/StatusSiteBundle/Controller/ApiController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace phpBB\StatusSiteBundle\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Response;
+
+class ApiController extends Controller
+{
+	public function warningAction()
+	{
+		$config = $this->getDoctrine()
+			->getRepository('phpBBStatusSiteBundle:Config');
+
+		$output = array(
+			'active' => $config->find('downtimeWarningActive')->getConfigValue(),
+			'name' => $config->find('downtimeWarningName')->getConfigValue(),
+			'content' => $config->find('downtimeWarningContent')->getConfigValue(),
+			'link' => $config->find('downtimeReadMoreLink')->getConfigValue()
+		);
+
+		$jsonOutput = json_encode($output);
+
+		$headers = array(
+			'Content-Type' => 'application/json'
+		);
+
+		$response = new Response($jsonOutput, 200, $headers);
+
+		return $response;
+	}
+}

--- a/src/phpBB/StatusSiteBundle/Entity/Config.php
+++ b/src/phpBB/StatusSiteBundle/Entity/Config.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace phpBB\StatusSiteBundle\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="config")
+ */
+class Config
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="string")
+     */
+	protected $config_name;
+
+    /**
+     * @ORM\Column(type="string")
+     */
+	protected $config_value;
+
+    /**
+     * Set config_name
+     *
+     * @param string $configName
+     * @return Config
+     */
+    public function setConfigName($configName)
+    {
+        $this->config_name = $configName;
+    
+        return $this;
+    }
+
+    /**
+     * Get config_name
+     *
+     * @return string 
+     */
+    public function getConfigName()
+    {
+        return $this->config_name;
+    }
+
+    /**
+     * Set config_value
+     *
+     * @param string $configValue
+     * @return Config
+     */
+    public function setConfigValue($configValue)
+    {
+        $this->config_value = $configValue;
+    
+        return $this;
+    }
+
+    /**
+     * Get config_value
+     *
+     * @return string 
+     */
+    public function getConfigValue()
+    {
+        return $this->config_value;
+    }
+}

--- a/src/phpBB/StatusSiteBundle/Resources/config.sql
+++ b/src/phpBB/StatusSiteBundle/Resources/config.sql
@@ -1,0 +1,5 @@
+INSERT INTO `config` (`config_name`, `config_value`) VALUES
+('downtimeReadMoreLink', 'http://status.phpbb.com'),
+('downtimeWarningActive', '1'),
+('downtimeWarningContent', 'This is just a text'),
+('downtimeWarningName', 'testing1');

--- a/src/phpBB/StatusSiteBundle/Resources/config/routing.yml
+++ b/src/phpBB/StatusSiteBundle/Resources/config/routing.yml
@@ -5,12 +5,15 @@ homepage:
 site:
     pattern: /site/{slug}
     defaults: { _controller: phpBBStatusSiteBundle:Default:site }
-    
+
 contact:
     pattern: /contact
     defaults: { _controller: phpBBStatusSiteBundle:Default:contact }
-        
+
 purge:
     pattern: /purge/
     defaults: { _controller: phpBBStatusSiteBundle:Default:purge }
 
+api_warning:
+    pattern: /api/downtime-warning/
+    defaults: { _controller: phpBBStatusSiteBundle:Api:warning }

--- a/src/phpBB/StatusSiteBundle/Resources/config/services.yml
+++ b/src/phpBB/StatusSiteBundle/Resources/config/services.yml
@@ -29,3 +29,9 @@ services:
         arguments: [null, phpBB\StatusSiteBundle\Entity\Updates, 'SonataAdminBundle:CRUD']
         tags:
             - { name: sonata.admin, manager_type: orm, group: Status, label: Updates }
+
+    phpbb_status_site.admin.config:
+        class: phpBB\StatusSiteBundle\Admin\ConfigAdmin
+        arguments: [null, phpBB\StatusSiteBundle\Entity\Config, 'SonataAdminBundle:CRUD']
+        tags:
+            - { name: sonata.admin, manager_type: orm, group: Status, label: Config }

--- a/src/phpBB/StatusSiteBundle/Resources/doc/ConfigVariablesGuide.md
+++ b/src/phpBB/StatusSiteBundle/Resources/doc/ConfigVariablesGuide.md
@@ -1,0 +1,7 @@
+Here is a list of all config db values:
+
+# Downtime External Warnings
+* downtimeWarningActive - This should be 0 to make it inactive or 1 to make it active.
+* downtimeWarningName - This is the name for the current downtime. This should never have the same value twice and is used as the cookie name on phpBB.com
+* downtimeWarningContent - The content for the external warning.
+* downtimeReadMoreLink - Link to status.phpbb.com


### PR DESCRIPTION
Creates a JSON response which phpBB.com (and other sites) can check and display.
- Active - If 1 then it will display on other sites, if 0 then it won't
- Name - Used to make it dismissable, this can be used as a cookie name
- Content - The message content, must be plaintext
- URL - Link to the status site for more information.

In addition this adds a config table which needs adding to local installs. For some basic test fixtures see `src/phpBB/StatusSiteBundle/Resources/config.sql`. This should be kept updated.

`src/phpBB/StatusSiteBundle/Resources/doc/ConfigVariablesGuide.md` should be update. It is a doc file for all possible config values.
