### PR TITLE
Fix scrutinizer dual composer install

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -17,6 +17,3 @@ tools:
         config:
             use_statement_fixes:
                 preserve_multiple: true
-    
-before_commands:
-    - composer install --dev


### PR DESCRIPTION
Remove the before script composer install as it already does this itself.
